### PR TITLE
moves non public needed ptr variable

### DIFF
--- a/include/IO.h
+++ b/include/IO.h
@@ -51,7 +51,6 @@ void WriteUnsignedInt(uint16 value);
 void WriteStringNoTerminator(char* string, uint16 size);
 void WriteData(char* data, uint16 size);
 
-char** ptr;
 #ifdef __cplusplus
 }
 #endif

--- a/src/IO.c
+++ b/src/IO.c
@@ -26,6 +26,8 @@
 #include <stdio.h>
 #include "IO.h"
 
+static char** ptr;
+
 void ReadAndIgnoreBytes(char** ptr, char* end)
 {
     while (*ptr != end)


### PR DESCRIPTION
makes it buildable with recent MinGW-64 gcc 13.x and clang 17.x